### PR TITLE
Remove broken badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Pawn
 
-[![buddy pipeline](https://app.buddy.works/willebaldogomez/pawn/pipelines/pipeline/154422/badge.svg?token=c4ea6d53ab0559f27ed4c57a68e3c44dccf580116cd9e314300b7399b3219de5 "buddy pipeline")](https://app.buddy.works/willebaldogomez/pawn/pipelines/pipeline/154422)
-
 A chess engine and machine learning testbed
 
 Originally written as a project to investigate AI techniques, Pawn is now at a decent strength to beat average players. It has been tested against some popular enginess (such as GnuChess) as part of its training to evolve with some satisfactory results.


### PR DESCRIPTION
I am adding this change because I noticed that the badge was broken and the CI/CD pipeline is no longer active.