### PR TITLE
Fix broken build

### DIFF
--- a/src/Move.cpp
+++ b/src/Move.cpp
@@ -42,16 +42,6 @@ Move::Move ()
    this->captured_piece = Piece::NULL_PIECE;
 }
 
-Move::Move (const Move& move)
-{
-   this->score = move.score;
-   this->start = move.start;
-   this->end = move.end;
-   this->type = move.type;
-   this->moving_piece = move.moving_piece;
-   this->captured_piece = move.captured_piece;
-}
-
 /*=============================================================================
   Create a move without specifying its type.
 

--- a/src/Move.hpp
+++ b/src/Move.hpp
@@ -13,7 +13,7 @@ class Move
    Move ();
    Move (const std::string& notation);
    Move (BoardSquare start, BoardSquare end);
-   Move (const Move&);
+   Move (const Move&) = default;
 
    enum Type {
       SIMPLE_MOVE,


### PR DESCRIPTION
`make` reports the following errors with recent versions of `gcc`:

```
src/Move.hpp:16:4: error: definition of implicit copy assignment operator for 'Move' is deprecated because it has a user-declared copy constructor [-Werror,-Wdeprecated-copy]
   Move (const Move&);
```

This is easily fixed by removing the explicit constructor and using a default one.