### PR TITLE
Make auto-play mode a default option

### DIFF
--- a/src/mae.cpp
+++ b/src/mae.cpp
@@ -35,7 +35,7 @@ using diagnostics::Timer;
 int
 main ()
 {
-  bool auto_play = false;
+  bool auto_play = true;
   bool xboard_mode = false;
 
   unique_ptr<IBoard> board(new MaeBoard());


### PR DESCRIPTION
It is a bit confusing that auto-play mode is the default option in GUI mode, but not in console mode. This fixes that.