### PR TITLE
Ensure clean compilation for g++ 11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ UNIT_TEST_INCLUDE_DIR = -I./src
 DEP_FLAGS = -MT $@ -MMD -MF $(DEP_DIR)/$*.Td
 
 # LIBRARIES
-LIBS = -lm # math
+LIBS = -lm -lstdc++ # math and standard c++ library
 UNIT_TEST_LIBS =
 
 # PROJECT SETTINGS

--- a/src/Util.hpp
+++ b/src/Util.hpp
@@ -3,6 +3,7 @@
 
 #include <climits>
 #include <vector>
+#include <cstddef>
 
 typedef unsigned short int ushort;
 typedef unsigned int uint;


### PR DESCRIPTION
g++ 11 no longer automatically links against the C++ standard library, so we must explicitly do that. Likewise, we must explicitly add `<cstddef>` for the `size_t` type to be visible.