### PR TITLE
Refactor statistics out of `AlphaBetaSearch`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # COMPILER SETTINGS
 CXX = g++
 
-CXXFLAGS = -g -Wall -Wextra -Werror -O2 -std=c++11 # compiler flags
+CXXFLAGS = -g -Wall -Wextra -Werror -O2 -std=c++14 # compiler flags
 CPPFLAGS = # preprocessor flags
 
 UNIT_TEST_INCLUDE_DIR = -I./src

--- a/src/AlphaBetaSearch.hpp
+++ b/src/AlphaBetaSearch.hpp
@@ -26,9 +26,7 @@ class AlphaBetaSearch : public IEngine
    int alpha_beta (uint depth, int alpha, int beta);
    int quiescence (uint depth, int alpha, int beta);
    int iterative_deepening (std::vector<game_rules::Move>& principal_variation);
-
-   void print_statistics (std::vector<game_rules::Move>& principal_variation);
-   void reset_statistics ();
+   int evaluate_position(const game_rules::IBoard* board);
 
    bool build_principal_variation (game_rules::IBoard*, std::vector<game_rules::Move>& principal_variation);
    void load_factor_weights (std::vector<int>& weights);
@@ -38,8 +36,8 @@ class AlphaBetaSearch : public IEngine
    TranspositionTable* transposition_table;
    game_rules::IBoard* board;
 
+
    GameResult result;
-   uint hash_table_hits;
    game_rules::Move best_move;
 
   public:

--- a/src/IEngine.hpp
+++ b/src/IEngine.hpp
@@ -2,6 +2,7 @@
 #define ICHESS_ENGINE_H
 
 #include "Util.hpp"
+#include "SearchStats.hpp"
 
 namespace game_rules { class IBoard; class Move; }
 
@@ -22,20 +23,18 @@ class IEngine
 
    static const int DRAW_VALUE = 0;
    static const int MATE_VALUE = -util::constants::INFINITUM;
-   static const uint MAX_QUIESCENCE_DEPTH = 4;
+   static const uint MAX_QUIESCENCE_DEPTH = 10;
 
    IEngine () {}
    virtual ~IEngine () {}
 
    virtual void load_factor_weights (std::vector<int>& weights) = 0;
-   virtual GameResult get_best_move (uint depth, game_rules::IBoard*, game_rules::Move& best_move) = 0;
+   virtual GameResult get_best_move (uint max_depth, game_rules::IBoard*, game_rules::Move& best_move) = 0;
+
+   SearchStats statistics;
 
   protected:
    uint max_depth;
-   uint n_nodes_evaluated;
-   uint n_internal_nodes;
-   uint n_leaf_nodes;
-   uint average_branching_factor;
    int root_value;
 };
 

--- a/src/SearchStats.hpp
+++ b/src/SearchStats.hpp
@@ -1,0 +1,65 @@
+#ifndef SEARCH_STATS_H_
+#define SEARCH_STATS_H_
+
+#include "Util.hpp"
+#include <iostream>
+#include <locale>
+#include <cmath>
+
+namespace game_engine
+{
+  using std::cerr;
+  using std::endl;
+
+  struct separate_thousands : std::numpunct<char> {
+    char_type do_thousands_sep() const override { return ','; }  // separate with commas
+    string_type do_grouping() const override { return "\3"; } // groups of 3 digit
+  };
+
+  class SearchStats {
+  public:
+    SearchStats() {
+      // add thousands separators to numbers to make them easier to read
+      auto thousands = std::make_unique<separate_thousands>();
+      std::cerr.imbue(std::locale(std::cerr.getloc(), thousands.release()));
+    }
+
+    void print () const {
+      cerr << "-------------------------------------------------------" << endl;
+      cerr << "Nodes evaluated: " << this->nodes_evaluated << endl;
+      cerr << "\tLeaf nodes: " << this->leaf_nodes << endl;
+      cerr << "\tInternal nodes: " << this->internal_nodes << endl;
+      cerr << "Average branching factor: " << int(round(this->average_branching_factor)) << endl;
+      cerr << "Transposition table hits: " << this->cache_hits << endl;
+      cerr << "AlphaBeta cutoffs: " << this->alpha_beta_cutoffs << endl;
+      cerr << "-------------------------------------------------------" << endl;
+    }
+
+    void add_branching_factor(uint factor) {
+      // https://math.stackexchange.com/questions/106700/incremental-averaging
+      double mean = this->average_branching_factor;
+      mean += (factor - mean) / this->internal_nodes;
+      this->average_branching_factor = mean;
+    }
+
+    void reset ()
+    {
+      cerr << "Resetting search statistics..." << endl;
+      this->cache_hits = 0;
+      this->leaf_nodes = 0;
+      this->internal_nodes = 0;
+      this->nodes_evaluated = 0;
+      this->average_branching_factor = 0.0;
+      this->alpha_beta_cutoffs = 0;
+    }
+
+    uint cache_hits = 0;
+    uint leaf_nodes = 0;
+    uint internal_nodes = 0;
+    uint nodes_evaluated = 0;
+    double average_branching_factor = 0.0;
+    uint alpha_beta_cutoffs = 0;
+  };
+}
+
+#endif // SEARCH_STATS_H_

--- a/src/UserCommandExecuter.cpp
+++ b/src/UserCommandExecuter.cpp
@@ -165,7 +165,7 @@ void
 UserCommandExecuter::think ()
 {
    Move best_move;
-   uint depth = 3;
+   uint depth = 5;
 
    IEngine::GameResult result = this->game_engine->get_best_move (depth, board, best_move);
 


### PR DESCRIPTION
While refactoring, I noticed that the statistics seemed way off, so I discovered there was a major bug in the implementation of the iterative deepening search. I don't remember that bug having been present years ago when it was first written, so it is possible it slipped in during a later refactoring (the perils of not having tests!)

I took the opportunity to update the compilation to use C++14, and fortunately nothing broke.