### PR TITLE
Add compact reporter for unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ $(OBJ_DIR)/%.o: $(SRC_DIR)/%.$(SOURCE_EXT) $(DEP_DIR)/%.$(DEP_EXT) | ensure_fold
 $(BIN_DIR)/$(PROJECT): $(OBJS)
 	@echo "$(INFO_COLOR)Linking main executable $@...$(NO_COLOR)"
 	$(CXX) $(OBJS) $(LIBS) -o $@
-	mv $@ $(BIN_DIR)/$(MAIN_BIN_NAME)
+	cp $@ $(BIN_DIR)/$(MAIN_BIN_NAME)
 	@echo "$(INFO_COLOR)Main executable is at $(OK_COLOR)$(BIN_DIR)/$(MAIN_BIN_NAME)$(NO_COLOR)"
 
 # ensure that dependency files don't get corrupted if compilation ever fails
@@ -155,12 +155,17 @@ perf_test: $(PERF_TEST_BIN_DIR)/$(PERF_TEST_PROJECT) | ensure_folders
 	@echo "$(INFO_COLOR)Running performance tests ...$(NO_COLOR)"
 	./$(PERF_TEST_BIN_DIR)/$(PERF_TEST_PROJECT)
 
+ifeq ($(COMPACT),true)
+  REPORTER = | ./compact_reporter.py
+else
+  REPORTER =
+endif
+
 unit_test: $(UNIT_TEST_BIN_DIR)/$(UNIT_TEST_PROJECT) | ensure_folders
 	@echo "$(INFO_COLOR)Running unit tests ...$(NO_COLOR)"
-	./$(UNIT_TEST_BIN_DIR)/$(UNIT_TEST_PROJECT)
+	@./$(UNIT_TEST_BIN_DIR)/$(UNIT_TEST_PROJECT) --success $(REPORTER)
 
 ensure_folders:
-	@echo "$(INFO_COLOR)Creating folder structure...$(NO_COLOR)"
 	@$(call create-folders)
 
 # mark the dependency files as "precious" to make, so they won’t be automatically deleted

--- a/compact_reporter.py
+++ b/compact_reporter.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+import fileinput
+from functools import partial
+from collections import defaultdict
+
+# pip install rich
+from rich.console import Console
+console = Console()
+
+# Parse the output of our unit test harness via piping, like this:
+# test/unit/bin/pawn_unit_test --success | ./compact_reporter.py
+#
+# The original output looks like this, which is too verbose:
+#
+#-------------------------------------------------------------------------------
+# ::bits
+#   Random bitboards have few collisions
+# -------------------------------------------------------------------------------
+# test/unit/src/bitboard_test.cpp:16
+# ...............................................................................
+
+# test/unit/src/bitboard_test.cpp:29: PASSED:
+#   REQUIRE( collisions < uint(TRIALS * SQUARES * COLLISIONS_TOLERANCE) )
+# with expansion:
+#   18 < 32
+
+# -------------------------------------------------------------------------------
+# ::bits
+#   count_ones (random)
+# -------------------------------------------------------------------------------
+# test/unit/src/bitboard_test.cpp:34
+# ...............................................................................
+
+# test/unit/src/bitboard_test.cpp:47: PASSED:
+#   REQUIRE( failures == 0 )
+# with expansion:
+#   0 == 0
+#
+# The goal is to remove all the redundant ::<suite-name> headers and produce a
+# more compact and easier to read version, such as this one:
+#
+#::bits
+#    🥝️ Random bitboards have few collisions
+#    🥝️ count_ones (random)
+#    🥝️ count_ones (smoke)
+#    🥝️ lsb_position (smoke)
+#    🍅️ msb_position (smoke)
+# ::game::Board
+#    🥝️ Can add a piece to the board
+#    🥝️ Should return error on moving from empty square
+#    🥝️ Can add and remove a piece to the board
+#    🥝️ Can add multiple pieces to board
+#    🥝️ Can move a knight from one square to another
+#    🥝️ Can move a knight all around the board
+#    🥝️ Can get locations for all pieces
+#
+# We need to do this because none of the reporters from our testing library
+# (see https://github.com/catchorg/Catch2/blob/v2.x/docs/command-line.md)
+# support a compact format as we want it
+#
+FAILED_TEST_EMOJI = ":tomato-emoji:"
+PASSED_TEST_EMOJI = ":kiwi_fruit-emoji:"
+
+def print_suite(suite_name, tests):
+    console.print(f"[bold cyan]{suite_name}")
+    for test in tests:
+        indentation = 3*" "
+        outcome = PASSED_TEST_EMOJI if len(test['failed-assertions']) == 0 else FAILED_TEST_EMOJI
+        console.print(f"{indentation}{outcome} {test['name']}")
+
+
+def parse_test_name(lines):
+    suite_name, test_name = None, None
+    line = next(lines, None)
+    while line:
+        line = line.strip()
+        if line.startswith('::'):
+            suite_name, test_name = line, next(lines, '').strip()
+            # skip over the frame divider line so `parse_assertions`
+            # works fine
+            next(lines, None)
+            break
+        line = next(lines, None)
+    return suite_name, test_name
+
+
+def parse_assertions(lines):
+    passed, failed = [], []
+    line = next(lines, None)
+    while line and not line.startswith('---'):
+        if 'PASSED' in line:
+            passed.append(line)
+        elif 'FAILED' in line:
+            failed.append(line)
+        line = next(lines, None)
+    return passed, failed
+
+
+def parse_test_results(lines):
+    suite_name, test_name = parse_test_name(lines)
+    if not suite_name:
+        return None, None, None
+    passed, failed = parse_assertions(lines)
+    return suite_name, test_name, (passed, failed)
+
+
+if __name__ == '__main__':
+    # read from standard input
+    lines = fileinput.input()
+
+    results_by_suite = defaultdict(list)
+    while True:
+        suite_name, test_name, assertions = parse_test_results(lines)
+        if not suite_name:
+            break
+        results_by_suite[suite_name].append({
+            'name': test_name,
+            'passed-assertions': assertions[0],
+            'failed-assertions': assertions[1],
+        })
+
+    for suite_name, tests in results_by_suite.items():
+        print_suite(suite_name, tests)

--- a/test/perf/src/bitboard_test.cpp
+++ b/test/perf/src/bitboard_test.cpp
@@ -1,5 +1,6 @@
 #include <ctime>
 #include <functional>
+#include <iomanip>
 #include <iostream>
 #include <random>
 
@@ -16,7 +17,7 @@ using std::endl;
 double benchmark_count_ones(
     std::function<uint(bits::bitboard)> count_ones, std::vector<bits::bitboard> values)
 {
-    const uint TRIALS = 5;
+    const uint TRIALS = 10;
     clock_t start = clock();
     for (auto value : values)
     {
@@ -30,7 +31,7 @@ double benchmark_count_ones(
 std::vector<bits::bitboard> generate_bitboards()
 {
     std::vector<bits::bitboard> result;
-    const uint TRIALS = 10'000;
+    const uint TRIALS = 100'000;
     for (uint trials = 0; trials < TRIALS; trials++)
     {
         result.push_back(random_bitboard(1 * BITS_IN_BITBOARD / 10));

--- a/test/unit/src/bitboard_test.cpp
+++ b/test/unit/src/bitboard_test.cpp
@@ -11,76 +11,80 @@ using namespace bits;
 
 const uint SQUARES = 64;
 
-TEST_CASE("Random bitboards have few collisions", "[bits][random]")
+TEST_CASE("::bits")
 {
-    const uint TRIALS = 500;
-    const double COLLISIONS_TOLERANCE = 0.001; // 0.1%
+    SECTION("Random bitboards have few collisions", "[bits][random]")
+    {
+        const uint TRIALS = 500;
+        const double COLLISIONS_TOLERANCE = 0.001; // 0.1%
 
-    uint collisions = 0;
-    for (uint ones_count = 1; ones_count < SQUARES; ones_count++)
-        for (uint trials = 0; trials < TRIALS; trials++)
-        {
-            bitboard a = random_bitboard(ones_count);
-            bitboard b = random_bitboard(ones_count);
-            collisions += (a == b);
-        }
-    REQUIRE(collisions < uint(TRIALS * SQUARES * COLLISIONS_TOLERANCE));
-}
+        uint collisions = 0;
+        for (uint ones_count = 1; ones_count < SQUARES; ones_count++)
+            for (uint trials = 0; trials < TRIALS; trials++)
+            {
+                bitboard a = random_bitboard(ones_count);
+                bitboard b = random_bitboard(ones_count);
+                collisions += (a == b);
+            }
+        REQUIRE(collisions < uint(TRIALS * SQUARES * COLLISIONS_TOLERANCE));
+    }
 
-// Testing exhaustively is too slow, so we'll have to make do with a
-// random sample of numbers for each count of ones
-TEST_CASE("bits::count_ones (random)", "[bits][random]")
-{
-    const uint TRIALS = 1000;
-    for (uint ones_count = 1; ones_count < SQUARES; ones_count++)
-        for (uint trials = 0; trials < TRIALS; trials++)
-        {
-            bitboard value = random_bitboard(ones_count);
-            uint result = count_ones(value);
-            REQUIRE(result == count_ones_baseline(value));
-            REQUIRE(result == count_ones_shift(value));
-            REQUIRE(result == count_ones_adaptive(value));
-            REQUIRE(result == count_ones_std(value));
-        }
-}
+    // Testing exhaustively is too slow, so we'll have to make do with a
+    // random sample of numbers for each count of ones
+    SECTION("count_ones (random)", "[bits][random]")
+    {
+        const uint TRIALS = 1000;
+        uint failures = 0;
+        for (uint ones_count = 1; ones_count < SQUARES; ones_count++)
+            for (uint trials = 0; trials < TRIALS; trials++)
+            {
+                bitboard value = random_bitboard(ones_count);
+                uint result = count_ones(value);
+                failures += (result != count_ones_baseline(value));
+                failures += (result != count_ones_shift(value));
+                failures += (result != count_ones_adaptive(value));
+            }
+        REQUIRE(failures == 0);
+    }
 
-TEST_CASE("bits::count_ones (smoke)", "[bits][smoke]")
-{
-    REQUIRE(count_ones(0) == 0);
-    REQUIRE(count_ones(0b0001) == 1);
-    REQUIRE(count_ones(0b0010) == 1);
-    REQUIRE(count_ones(0b0011) == 2);
-    REQUIRE(count_ones(0b0100) == 1);
-    REQUIRE(count_ones(0b0101) == 2);
-    REQUIRE(count_ones(0b0110) == 2);
-    REQUIRE(count_ones(0b0111) == 3);
-    REQUIRE(count_ones(0b1000) == 1);
-}
+    SECTION("count_ones (smoke)", "[bits][smoke]")
+    {
+        REQUIRE(count_ones(0) == 0);
+        REQUIRE(count_ones(0b0001) == 1);
+        REQUIRE(count_ones(0b0010) == 1);
+        REQUIRE(count_ones(0b0011) == 2);
+        REQUIRE(count_ones(0b0100) == 1);
+        REQUIRE(count_ones(0b0101) == 2);
+        REQUIRE(count_ones(0b0110) == 2);
+        REQUIRE(count_ones(0b0111) == 3);
+        REQUIRE(count_ones(0b1000) == 1);
+    }
 
-TEST_CASE("bits::lsb_position (smoke)", "[bits][lsb][smoke]")
-{
-    REQUIRE(lsb_position(0) == -1);
-    REQUIRE(lsb_position(0b0001) == 0);
-    REQUIRE(lsb_position(0b0010) == 1);
-    REQUIRE(lsb_position(0b0011) == 0);
-    REQUIRE(lsb_position(0b0100) == 2);
-    REQUIRE(lsb_position(0b0101) == 0);
-    REQUIRE(lsb_position(0b0110) == 1);
-    REQUIRE(lsb_position(0b0111) == 0);
-    REQUIRE(lsb_position(0b1000) == 3);
-}
+    SECTION("lsb_position (smoke)", "[bits][lsb][smoke]")
+    {
+        REQUIRE(lsb_position(0) == -1);
+        REQUIRE(lsb_position(0b0001) == 0);
+        REQUIRE(lsb_position(0b0010) == 1);
+        REQUIRE(lsb_position(0b0011) == 0);
+        REQUIRE(lsb_position(0b0100) == 2);
+        REQUIRE(lsb_position(0b0101) == 0);
+        REQUIRE(lsb_position(0b0110) == 1);
+        REQUIRE(lsb_position(0b0111) == 0);
+        REQUIRE(lsb_position(0b1000) == 3);
+    }
 
-TEST_CASE("bits::msb_position (smoke)", "[bits][msb][smoke]")
-{
-    REQUIRE(msb_position(0) == -1);
-    REQUIRE(msb_position(0b0001) == 0);
-    REQUIRE(msb_position(0b0010) == 1);
-    REQUIRE(msb_position(0b0011) == 1);
-    REQUIRE(msb_position(0b0100) == 2);
-    REQUIRE(msb_position(0b0101) == 2);
-    REQUIRE(msb_position(0b0110) == 2);
-    REQUIRE(msb_position(0b0111) == 2);
-    REQUIRE(msb_position(0b1000) == 3);
+    SECTION("msb_position (smoke)", "[bits][msb][smoke]")
+    {
+        REQUIRE(msb_position(0) == -1);
+        REQUIRE(msb_position(0b0001) == 0);
+        REQUIRE(msb_position(0b0010) == 1);
+        REQUIRE(msb_position(0b0011) == 1);
+        REQUIRE(msb_position(0b0100) == 2);
+        REQUIRE(msb_position(0b0101) == 2);
+        REQUIRE(msb_position(0b0110) == 2);
+        REQUIRE(msb_position(0b0111) == 2);
+        REQUIRE(msb_position(0b1000) == 3);
+    }
 }
 
 } // anonymous namespace


### PR DESCRIPTION
Unfortunately Catch (https://github.com/catchorg/Catch2) doesn't support a reporter for tests results that is at the level of granularity that I like (i.e., with overall results for individual tests and grouped by suite), so I had to write a bit of an adapter to get a better report.

To use this reporter, one must invoke the unit test suite as follows:

```sh
COMPACT=true make unit_test
```

![tests-report](https://user-images.githubusercontent.com/442314/160723245-576fefaf-02fe-4c5b-8467-d749059168a4.png)

***
**NOTE**:
To be able to use this, one must have installed a recent version of Python (3.6+) and the [`rich`](https://github.com/Textualize/rich) library